### PR TITLE
결제 페이지 배송지 변경/추가 UX 개선 및 모달 접근성 강화

### DIFF
--- a/src/app/(pages)/(payment)/payment/components/(address)/AddressChangeButton.tsx
+++ b/src/app/(pages)/(payment)/payment/components/(address)/AddressChangeButton.tsx
@@ -1,19 +1,21 @@
+// AddressChangeButton.tsx
 'use client';
 
 import { AddressesList } from '@/components/common/address';
 import AddAddressForm from '@/components/common/address/AddAddressForm';
+import { BackButton } from '@/components/icons/BackButton';
+import { XClose } from '@/components/icons/XClose';
 import { Modal } from '@/components/ui/Modal';
 import { MODAL_IDS } from '@/constants';
 import { Address } from '@/types/deliveryAddress';
 import useDeliveryStore from '@/zustand/payment/useDeliveryStore';
 import { useModalStore } from '@/zustand/useModalStore';
-import clsx from 'clsx';
 import { useEffect, useState } from 'react';
 
 const AddressChangeButton: React.FC = () => {
-  const openModal = useModalStore((state) => state.open);
-  const closeModal = useModalStore((state) => state.close);
-  const openModalId = useModalStore((state) => state.openModalId);
+  const openModal = useModalStore((s) => s.open);
+  const closeModal = useModalStore((s) => s.close);
+  const openModalId = useModalStore((s) => s.openModalId);
 
   const address = useDeliveryStore((s) => s.address);
 
@@ -23,11 +25,53 @@ const AddressChangeButton: React.FC = () => {
     setMode('list');
     closeModal();
   };
+
   useEffect(() => {
-    if (openModalId !== MODAL_IDS.ADDRESS) {
-      setMode('list');
-    }
+    if (openModalId !== MODAL_IDS.ADDRESS) setMode('list');
   }, [openModalId]);
+
+  const listModeHeader = (
+    <div className="flex justify-between items-center w-full">
+      <button
+        type="button"
+        onClick={handleModalClose}
+        className="flex items-center justify-center"
+        aria-label="닫기"
+      >
+        <BackButton />
+      </button>
+      <h3 className="text-lg font-medium">배송지 변경</h3>
+      <button
+        type="button"
+        onClick={() => setMode('add')}
+        className="text-base font-medium text-primary-20"
+      >
+        추가
+      </button>
+    </div>
+  );
+
+  const addModeHeader = (
+    <div className="flex justify-between items-center w-full">
+      <button
+        type="button"
+        onClick={() => setMode('list')}
+        className="w-7 h-7 flex items-center justify-center"
+        aria-label="뒤로가기"
+      >
+        <BackButton />
+      </button>
+      <h3 className="text-lg font-medium">배송지 추가</h3>
+      <button
+        type="button"
+        onClick={handleModalClose}
+        className="w-7 h-7 flex items-center justify-center"
+        aria-label="닫기"
+      >
+        <XClose />
+      </button>
+    </div>
+  );
 
   return (
     <>
@@ -37,32 +81,21 @@ const AddressChangeButton: React.FC = () => {
       >
         변경
       </button>
+
       <Modal
         modalId={MODAL_IDS.ADDRESS}
-        headerTitle={mode === 'add' ? '배송지 추가' : '배송지 변경'}
+        header={mode === 'add' ? addModeHeader : listModeHeader}
+        width={471}
+        height={710}
         isFullOnMobile
       >
         {mode === 'add' ? (
           <AddAddressForm
-            // 등록 완료 시 동작
-            onSuccess={() => {
-              handleModalClose();
-            }}
+            onSuccess={handleModalClose}
             onCancel={() => setMode('list')}
           />
         ) : (
-          <>
-            <AddressesList initialData={address as Address[]} isSelecting />
-            <button
-              className={clsx(
-                'w-full py-3 rounded-[8px] cursor-pointer mt-4',
-                'bg-primary-20 text-white'
-              )}
-              onClick={() => setMode('add')}
-            >
-              새 배송지 추가
-            </button>
-          </>
+          <AddressesList initialData={address as Address[]} isSelecting />
         )}
       </Modal>
     </>

--- a/src/app/(pages)/(payment)/payment/components/(address)/AddressChangeButton.tsx
+++ b/src/app/(pages)/(payment)/payment/components/(address)/AddressChangeButton.tsx
@@ -1,27 +1,33 @@
-// 배송지 변경 버튼
-
-// 모바일 사이즈 : 배송지 변경 페이지로 이동
-// 데스크탑 사이즈 : 배송지 변경 모달
-
-//TODO : 데스크탑 사이즈에서 모달 띄우기(컴포넌트들 가져오기)
-
 'use client';
 
 import { AddressesList } from '@/components/common/address';
+import AddAddressForm from '@/components/common/address/AddAddressForm';
 import { Modal } from '@/components/ui/Modal';
 import { MODAL_IDS } from '@/constants';
 import { Address } from '@/types/deliveryAddress';
 import useDeliveryStore from '@/zustand/payment/useDeliveryStore';
 import { useModalStore } from '@/zustand/useModalStore';
-import React from 'react';
+import clsx from 'clsx';
+import { useEffect, useState } from 'react';
 
-interface Props {
-  selectedAddressId: string;
-}
-
-const AddressChangeButton: React.FC<Props> = ({ selectedAddressId }) => {
+const AddressChangeButton: React.FC = () => {
   const openModal = useModalStore((state) => state.open);
+  const closeModal = useModalStore((state) => state.close);
+  const openModalId = useModalStore((state) => state.openModalId);
+
   const address = useDeliveryStore((s) => s.address);
+
+  const [mode, setMode] = useState<'list' | 'add'>('list');
+
+  const handleModalClose = () => {
+    setMode('list');
+    closeModal();
+  };
+  useEffect(() => {
+    if (openModalId !== MODAL_IDS.ADDRESS) {
+      setMode('list');
+    }
+  }, [openModalId]);
 
   return (
     <>
@@ -33,10 +39,31 @@ const AddressChangeButton: React.FC<Props> = ({ selectedAddressId }) => {
       </button>
       <Modal
         modalId={MODAL_IDS.ADDRESS}
-        headerTitle="배송지 변경"
+        headerTitle={mode === 'add' ? '배송지 추가' : '배송지 변경'}
         isFullOnMobile
       >
-        <AddressesList initialData={address as Address[]} isSelecting />
+        {mode === 'add' ? (
+          <AddAddressForm
+            // 등록 완료 시 동작
+            onSuccess={() => {
+              handleModalClose();
+            }}
+            onCancel={() => setMode('list')}
+          />
+        ) : (
+          <>
+            <AddressesList initialData={address as Address[]} isSelecting />
+            <button
+              className={clsx(
+                'w-full py-3 rounded-[8px] cursor-pointer mt-4',
+                'bg-primary-20 text-white'
+              )}
+              onClick={() => setMode('add')}
+            >
+              새 배송지 추가
+            </button>
+          </>
+        )}
       </Modal>
     </>
   );

--- a/src/app/(pages)/(payment)/payment/components/(address)/AddressChangeButton.tsx
+++ b/src/app/(pages)/(payment)/payment/components/(address)/AddressChangeButton.tsx
@@ -7,7 +7,12 @@
 
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { AddressesList } from '@/components/common/address';
+import { Modal } from '@/components/ui/Modal';
+import { MODAL_IDS } from '@/constants';
+import { Address } from '@/types/deliveryAddress';
+import useDeliveryStore from '@/zustand/payment/useDeliveryStore';
+import { useModalStore } from '@/zustand/useModalStore';
 import React from 'react';
 
 interface Props {
@@ -15,30 +20,24 @@ interface Props {
 }
 
 const AddressChangeButton: React.FC<Props> = ({ selectedAddressId }) => {
-  //TODO selectAddressId 가 빈 문자열일 때 처리 추가
-  const router = useRouter();
-  const ADDRESS_LIST_PAGE = '/my-page/setting/delivery-address';
-
-  const handleClick = () => {
-    // // if (isMobile) {
-    // router.push(
-    //   `${ADDRESS_LIST_PAGE}?from=payment&addressId=${selectedAddressId}`
-    // );
-    // // }
-    // // if (isDesktop) {
-    // //   setIsModalOpen(true);
-    // // }
-  };
+  const openModal = useModalStore((state) => state.open);
+  const address = useDeliveryStore((s) => s.address);
 
   return (
     <>
       <button
         className="text-xs font-normal text-[#79746D] border-[1px] border-[#959595] rounded-[6px] py-1 px-2"
-        onClick={handleClick}
+        onClick={() => openModal(MODAL_IDS.ADDRESS)}
       >
         변경
       </button>
-      {/* TODO 모달 들어갈 자리 */}
+      <Modal
+        modalId={MODAL_IDS.ADDRESS}
+        headerTitle="배송지 변경"
+        isFullOnMobile
+      >
+        <AddressesList initialData={address as Address[]} isSelecting />
+      </Modal>
     </>
   );
 };

--- a/src/app/(pages)/(payment)/payment/components/(address)/AddressSummaryCard.tsx
+++ b/src/app/(pages)/(payment)/payment/components/(address)/AddressSummaryCard.tsx
@@ -1,15 +1,13 @@
 import { Address } from '@/types/deliveryAddress';
 import React from 'react';
-import AddressChangeButton from './AddressChangeButton';
 
 interface Props {
   selectedAddress: Address;
 }
 
 const AddressSummaryCard: React.FC<Props> = ({ selectedAddress }) => {
-  //TODO Address prop의 유효성 검사 추가 (undefined나 null일 경우)
   const {
-    id,
+    // id,
     addressName,
     receiverName,
     phoneNumber,
@@ -19,15 +17,13 @@ const AddressSummaryCard: React.FC<Props> = ({ selectedAddress }) => {
 
   const zipCode = baseAddress.match(/\((\d+)\)/)?.[1];
   const baseAddressWithoutZipCode = baseAddress.split('(')[0];
+
   return (
     <div className="flex flex-col gap-2">
       <div className="flex justify-between items-center">
         <p className="text-label-strong text-[16px] font-semibold">
           {addressName}
         </p>
-
-        {/* 변경 버튼 */}
-        <AddressChangeButton selectedAddressId={id} />
       </div>
       <p className="text-label-strong">{receiverName}</p>
       <p className="text-label-alternative">{phoneNumber}</p>

--- a/src/app/(pages)/(payment)/payment/components/(address)/DeliveryAddress.tsx
+++ b/src/app/(pages)/(payment)/payment/components/(address)/DeliveryAddress.tsx
@@ -65,7 +65,12 @@ export default function DeliveryAddress({
     setShippingRequest(initialShippingRequest);
   }, [initialShippingRequest, setShippingRequest]);
 
-  //TODO 컴포넌트 언마운트 시,  ZUSTAND 초기화
+  // 언마운트 시 초기화
+  useEffect(() => {
+    return () => {
+      useDeliveryStore.persist.clearStorage();
+    };
+  }, []);
 
   return (
     <div

--- a/src/app/(pages)/(payment)/payment/components/(address)/DeliveryAddress.tsx
+++ b/src/app/(pages)/(payment)/payment/components/(address)/DeliveryAddress.tsx
@@ -66,7 +66,6 @@ export default function DeliveryAddress({
   }, [initialShippingRequest, setShippingRequest]);
 
   //TODO 컴포넌트 언마운트 시,  ZUSTAND 초기화
-  //TODO ZUSTAND 정리 (필요 요소, 불필요 요소 확인)
 
   return (
     <div
@@ -84,9 +83,7 @@ export default function DeliveryAddress({
       ) : (
         <div className={clsx('flex justify-between items-start')}>
           <AddressSummaryCard selectedAddress={selectedAddress} />
-          <AddressChangeButton
-            selectedAddressId={selectedAddress?.id as string}
-          />
+          <AddressChangeButton />
         </div>
       )}
 

--- a/src/app/(pages)/(payment)/payment/components/(address)/DeliveryAddress.tsx
+++ b/src/app/(pages)/(payment)/payment/components/(address)/DeliveryAddress.tsx
@@ -16,6 +16,7 @@ import DownButton from '@/components/icons/DownButton';
 import UpButton from '@/components/icons/UpButton';
 
 import AddAddressButton from './AddAddressButton';
+import AddressChangeButton from './AddressChangeButton';
 import AddressSummaryCard from './AddressSummaryCard';
 
 interface Props {
@@ -31,8 +32,8 @@ export default function DeliveryAddress({
 
   // Zustand
   const addresses = useDeliveryStore((s) => s.address);
-  const shippingRequest = useDeliveryStore((s) => s.shippingRequest);
   const selectedAddressId = useDeliveryStore((s) => s.selectedAddressId);
+  const shippingRequest = useDeliveryStore((s) => s.shippingRequest);
   const shouldStoreDeliveryRequest = useDeliveryStore(
     (s) => s.shouldStoreDeliveryRequest
   );
@@ -59,7 +60,7 @@ export default function DeliveryAddress({
   // Initialize store from props
   useEffect(() => {
     setAddress(initialAddress);
-  }, [initialAddress]);
+  }, [initialAddress, setAddress]);
   useEffect(() => {
     setShippingRequest(initialShippingRequest);
   }, [initialShippingRequest, setShippingRequest]);
@@ -81,7 +82,12 @@ export default function DeliveryAddress({
       {!selectedAddress ? (
         <AddAddressButton />
       ) : (
-        <AddressSummaryCard selectedAddress={selectedAddress} />
+        <div className={clsx('flex justify-between items-start')}>
+          <AddressSummaryCard selectedAddress={selectedAddress} />
+          <AddressChangeButton
+            selectedAddressId={selectedAddress?.id as string}
+          />
+        </div>
       )}
 
       <div className="w-full h-px bg-gray-200 my-2" />

--- a/src/app/(pages)/(payment)/payment/components/OrderPageIntro.tsx
+++ b/src/app/(pages)/(payment)/payment/components/OrderPageIntro.tsx
@@ -1,7 +1,7 @@
 import InfoIcon from '@/components/icons/InfoIcon';
 import Image from 'next/image';
 
-const DesktopOrderHeader = () => {
+const OrderPageIntro = () => {
   return (
     <div className="flex flex-col items-center gap-2">
       <Image
@@ -24,4 +24,4 @@ const DesktopOrderHeader = () => {
   );
 };
 
-export default DesktopOrderHeader;
+export default OrderPageIntro;

--- a/src/app/(pages)/(payment)/payment/page.tsx
+++ b/src/app/(pages)/(payment)/payment/page.tsx
@@ -1,14 +1,14 @@
-import HeaderWithInfoIcon from '@/components/common/header/_component/HeaderWithInfoIcon';
-import { getAddressesInServerComponent } from '@/hooks/deliveryAddress/useAddressesServer';
-import { Address } from '@/types/deliveryAddress';
 import { createClient } from '@/utils/supabase/server';
+
+import { getAddressesInServerComponent } from '@/hooks/deliveryAddress/useAddressesServer';
+
+import HeaderWithInfoIcon from '@/components/common/header/_component/HeaderWithInfoIcon';
+import clsx from 'clsx';
 import DeliveryAddress from './components/(address)/DeliveryAddress';
 import CouponInPaymentPage from './components/CouponInPaymentPage';
-import DesktopOrderHeader from './components/DesktopOrderHeader';
+import OrderPageIntro from './components/OrderPageIntro';
 import PaymentMethodSelect from './components/PaymentMethodSelect';
 
-// TODO 1. 전체 리팩토링 이후
-// TODO 2. 배송지 변경 - 반응형 대응. (풀화면 <-> 모달)
 const Payment = async () => {
   //툴팁 내용
   const toolTipContentArray = [
@@ -18,11 +18,14 @@ const Payment = async () => {
     '주문 내역에서 주문 취소 버튼을 통해 환불 가능합니다.'
   ];
 
-  // 초기 주소 및 요청 사항 가져오기
-  const allAddresses: Address[] = await getAddressesInServerComponent();
-  const supabase = createClient();
+  // 주소
+  const { addresses } = await getAddressesInServerComponent();
+
+  // 유저 정보
+  const supabase = createClient(); //server
   const { data } = await supabase.auth.getUser();
 
+  // 배송 요청 사항
   let shippingRequest = '';
   if (data.user) {
     const user = data.user;
@@ -44,15 +47,22 @@ const Payment = async () => {
         isIncludeIconHighlighting={true}
       />
       {/* 데스크탑 헤더 */}
-      <div className="hidden md:block md:mt-16">
-        <DesktopOrderHeader />
+      <div className={clsx('hidden md:block', 'md:mt-16')}>
+        <OrderPageIntro />
       </div>
-      {/* 결제 페이지 주요 컴포넌트 */}
-      <main className="mx-auto md:max-w-[1080px] p-4 md:p-0 bg-normal mb-14 mt-16 md:mt-0 md:flex md:gap-6">
+      {/* content */}
+      <main
+        className={clsx(
+          'mx-auto p-4 md:p-0 mb-14 mt-16 md:mt-0',
+          'md:max-w-[1080px]',
+          'bg-normal',
+          'md:flex md:gap-6'
+        )}
+      >
         {/* 좌측: 배송지, 주문상품, 쿠폰, 결제수단 */}
-        <section className="md:flex-1 md:max-w-[681px] space-y-6">
+        <section className={clsx('space-y-6', 'md:flex-1 md:max-w-[681px]')}>
           <DeliveryAddress
-            initialAddress={allAddresses}
+            initialAddress={addresses}
             initialShippingRequest={shippingRequest}
           />
           {/* <OrderProducts /> */}

--- a/src/app/(pages)/my-page/setting/delivery-address/add-new/page.tsx
+++ b/src/app/(pages)/my-page/setting/delivery-address/add-new/page.tsx
@@ -1,7 +1,14 @@
+'use client';
+
 import AddAddressForm from '@/components/common/address/AddAddressForm';
 import InfoIcon from '@/components/icons/InfoIcon';
+import { useRouter } from 'next/navigation';
 
 const AddNewAddress = () => {
+  const router = useRouter();
+  const onSuccess = () => {
+    router.push('/my-page/setting/delivery-address');
+  };
   return (
     <>
       {/* 안내 메시지 */}
@@ -14,7 +21,7 @@ const AddNewAddress = () => {
 
       <main className="w-full mx-auto bg-normal p-4">
         {/* 배송지 입력 폼 */}
-        <AddAddressForm />
+        <AddAddressForm onSuccess={onSuccess} />
       </main>
     </>
   );

--- a/src/app/template.tsx
+++ b/src/app/template.tsx
@@ -131,7 +131,7 @@ export default function Template({ children }: { children: React.ReactNode }) {
   }
   // 결제 페이지
   else if (pathName === '/payment') {
-    showHeader = false;
+    showHeader = true;
     showSearch = false;
     showCart = false;
     showNavigation = false;

--- a/src/components/common/address/AddAddressForm.tsx
+++ b/src/components/common/address/AddAddressForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import useThrottle from '@/hooks/useThrottle';
 import { useUser } from '@/hooks/useUser';
@@ -14,7 +14,15 @@ import { toast } from '@/components/ui/use-toast';
 import useDaumPostcode from '@/hooks/deliveryAddress/daumPostCode/usePopup';
 import clsx from 'clsx';
 
-const AddAddressForm = () => {
+interface AddAddressFormProps {
+  onSuccess?: () => void; // 등록 성공 시
+  onCancel?: () => void; // 취소/뒤로
+}
+
+const AddAddressForm: React.FC<AddAddressFormProps> = ({
+  onSuccess,
+  onCancel
+}) => {
   const router = useRouter();
 
   const [formattedPhoneNumber, setFormattedPhoneNumber] = useState('');
@@ -135,7 +143,7 @@ const AddAddressForm = () => {
     e.currentTarget.reset();
     setValidationErrors({});
 
-    router.push('/my-page/setting/delivery-address');
+    if (onSuccess) onSuccess(); // 콜백 호출
   };
 
   //throttling 적용

--- a/src/components/common/address/AddressItem.tsx
+++ b/src/components/common/address/AddressItem.tsx
@@ -1,9 +1,6 @@
-//수정, 삭제 로직은 리스트에서 prop으로 넘겨받고
-//해당 컴포넌트는 최대한 ui 렌더링만 역할 남겼습니다 - 종훈
-
 'use client';
-
 import { Address } from '@/types/deliveryAddress';
+import clsx from 'clsx';
 
 interface Props {
   address: Address | Address[];
@@ -11,6 +8,8 @@ interface Props {
   updateDeliveryAddress: (e: React.MouseEvent<HTMLButtonElement>) => void;
   deleteDeliveryAddress: (e: React.MouseEvent<HTMLButtonElement>) => void;
   selectedAddressId: string | null;
+  isSelecting?: boolean; // 배송지 선택 모드 여부
+  radioOnChange?: () => void;
 }
 
 const AddressItem = ({
@@ -18,7 +17,9 @@ const AddressItem = ({
   isDefaultAddress,
   updateDeliveryAddress,
   deleteDeliveryAddress,
-  selectedAddressId
+  selectedAddressId,
+  isSelecting = false,
+  radioOnChange
 }: Props) => {
   const {
     id,
@@ -71,7 +72,12 @@ const AddressItem = ({
         </div>
       </div>
 
-      <div className="flex items-center gap-2 font-normal text-label-normal text-[14px]">
+      <div
+        className={clsx(
+          'flex items-center gap-2',
+          'font-normal text-label-normal text-[14px]'
+        )}
+      >
         <button onClick={updateDeliveryAddress}>수정</button>
         <span>|</span>
         <button onClick={deleteDeliveryAddress}>삭제</button>

--- a/src/components/common/address/AddressItem.tsx
+++ b/src/components/common/address/AddressItem.tsx
@@ -33,11 +33,19 @@ const AddressItem = ({
 
   return (
     <div
-      className={`p-4 bg-white w-full flex flex-col gap-2 border rounded-xl ${
+      className={clsx(
+        'bg-white w-full',
+        'flex flex-col',
+        isSelecting ? 'gap-0' : 'gap-3',
+        'p-4',
+        'border rounded-xl',
+        'shadow-sm',
         selectedAddressId === id ? 'border-primary-20' : 'border-[#E0E0E0]'
-      }`}
+      )}
     >
-      <div className="flex items-center gap-2">
+      <div
+        className={clsx('flex items-center gap-2', isSelecting && 'text-xs')}
+      >
         <p
           className={`font-semibold text-[16px] ${
             selectedAddressId === id ? 'text-primary-20' : 'text-label-strong'
@@ -46,7 +54,7 @@ const AddressItem = ({
           {addressName}
         </p>
         {isDefaultAddress && (
-          <span className="px-2 py-1 text-xs border bg-[#F2F2F2] text-label-strong rounded-[6px]">
+          <span className="px-2 py-1 text-xs bg-[#F2F2F2] text-label-strong rounded-[6px]">
             기본 배송지
           </span>
         )}
@@ -73,12 +81,23 @@ const AddressItem = ({
       <div
         className={clsx(
           'flex items-center gap-2',
-          'font-normal text-label-normal text-[14px]'
+          'font-normal text-label-normal text-[14px]',
+          'pt-2 border-t border-gray-100'
         )}
       >
-        <button onClick={updateDeliveryAddress}>수정</button>
-        <span>|</span>
-        <button onClick={deleteDeliveryAddress}>삭제</button>
+        <button
+          onClick={updateDeliveryAddress}
+          className="hover:text-primary-20 transition-colors"
+        >
+          수정
+        </button>
+        <span className="text-gray-300">|</span>
+        <button
+          onClick={deleteDeliveryAddress}
+          className="hover:text-red-500 transition-colors"
+        >
+          삭제
+        </button>
       </div>
     </div>
   );

--- a/src/components/common/address/AddressItem.tsx
+++ b/src/components/common/address/AddressItem.tsx
@@ -9,7 +9,6 @@ interface Props {
   deleteDeliveryAddress: (e: React.MouseEvent<HTMLButtonElement>) => void;
   selectedAddressId: string | null;
   isSelecting?: boolean; // 배송지 선택 모드 여부
-  radioOnChange?: () => void;
 }
 
 const AddressItem = ({
@@ -18,8 +17,7 @@ const AddressItem = ({
   updateDeliveryAddress,
   deleteDeliveryAddress,
   selectedAddressId,
-  isSelecting = false,
-  radioOnChange
+  isSelecting = false
 }: Props) => {
   const {
     id,

--- a/src/components/common/address/AddressesList.tsx
+++ b/src/components/common/address/AddressesList.tsx
@@ -51,7 +51,6 @@ const AddressesList: React.FC<AddressListProps> = ({
     (state) => state.setSelectedAddressId
   );
   // Zustand - 모달
-  const openModal = useModalStore((state) => state.open);
   const closeModal = useModalStore((state) => state.close);
 
   useEffect(() => {

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -4,49 +4,55 @@ import { MODAL_IDS } from '@/constants';
 import { useModalStore } from '@/zustand/useModalStore';
 import clsx from 'clsx';
 import { usePathname } from 'next/navigation';
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { BackButton } from '../icons/BackButton';
 import { XClose } from '../icons/XClose';
 
-/**
- * MODAL_IDS 값들 중 하나만 허용
- */
 export type ModalId = (typeof MODAL_IDS)[keyof typeof MODAL_IDS];
 
 interface ModalProps {
   modalId: ModalId;
-  headerTitle: string;
-  className?: string;
-  width?: string;
-  height?: string;
-  isFullOnMobile?: boolean;
+  headerTitle?: string; // 기본 헤더 제목
+  header?: React.ReactNode; // 커스텀 헤더 노드
+  isFullOnMobile?: boolean; // 모바일 풀스크린 여부
+  width?: React.CSSProperties['width']; // 데스크탑 기준 너비
+  height?: React.CSSProperties['height']; // 데스크탑 기준 높이
+  className?: string; // 추가 클래스
   children: React.ReactNode;
 }
 
 /**
- * Modal 컴포넌트 (Zustand 활용, modalId 기준 제어)
- * @param {string} modalId - 모달 식별자 (Zustand 상태 관리용)
- * @param {string} headerTitle - 헤더 타이틀 텍스트
- * @param {string} [className] - 모달 컨테이너에 추가할 스타일(class)
- * @param {string} [width] - 데스크탑 기준 모달 너비(px)
- * @param {string} [height] - 데스크탑 기준 모달 높이(px)
- * @param {boolean} [isFullOnMobile] - 모바일에서 전체 화면 표시 여부
+ * Modal 컴포넌트 (Zustand 기반 modalId 제어 + 포털/스크롤 락 적용)
+ *
+ * @param {ModalId} modalId - 모달 식별자 (Zustand 상태 관리용)
+ * @param {string} [headerTitle] - 기본 헤더에서 표시할 타이틀 (header 미사용 시 적용)
+ * @param {React.ReactNode} [header] - 커스텀 헤더 노드 (지정 시 기본 헤더 대신 사용)
+ * @param {boolean} [isFullOnMobile] - 모바일 화면에서 전체 화면 표시 여부
+ * @param {string|number} [width] - 데스크탑 기준 모달 너비 (px, %, auto 등)
+ * @param {string|number} [height] - 데스크탑 기준 모달 높이 (px, %, auto 등)
+ * @param {string} [className] - 모달 컨테이너에 추가할 클래스
+ * @param {React.ReactNode} children - 모달 본문 콘텐츠
  */
 export const Modal: React.FC<ModalProps> = ({
   modalId,
   headerTitle,
-  className,
+  header,
+  isFullOnMobile,
   width,
   height,
-  isFullOnMobile,
+  className,
   children
 }) => {
   const pathname = usePathname();
-
   const openModalId = useModalStore((state) => state.openModalId);
   const close = useModalStore((state) => state.close);
+  const isOpen = openModalId === modalId;
 
-  // 페이지 경로가 변경될 때 모달 닫기
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  // 라우트 변경시 모달 닫기
   useEffect(() => {
     close();
   }, [pathname, close]);
@@ -58,81 +64,154 @@ export const Modal: React.FC<ModalProps> = ({
     };
   }, [close]);
 
-  // 자신이 열린 모달인지 체크
-  const isThisOpen = openModalId === modalId;
-  if (!isThisOpen) return null;
+  // 스크롤 락
+  useEffect(() => {
+    if (!isOpen) return;
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [isOpen]);
 
-  return (
+  // 포커스: 모달 열릴 때 컨테이너에 포커스
+  const modalRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!isOpen) return;
+    modalRef.current?.focus();
+  }, [isOpen]);
+
+  // 키보드: ESC 닫기만 지원
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        close();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown, { capture: true });
+    return () =>
+      window.removeEventListener('keydown', onKeyDown, { capture: true });
+  }, [isOpen, close]);
+
+  if (!mounted || !isOpen) return null;
+
+  const titleId = `${String(modalId)}-title`;
+
+  const content = (
     <div
       className={clsx(
-        'fixed inset-0 z-[9999] flex items-center justify-center',
-        // isFullOnMobile인 모바일에서는 오버레이 제거, 그 외에는 오버레이 유지
+        'fixed inset-0 z-[9999] flex',
+        'items-center justify-center',
+        // 모바일 풀스크린 시 오버레이 제거, md 이상에서만 오버레이 표시
         isFullOnMobile
           ? 'md:bg-black md:bg-opacity-50'
           : 'bg-black bg-opacity-50'
       )}
-      onClick={close}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={header ? undefined : titleId} // 최소 라벨: 기본 헤더만 연결
     >
       <div
+        ref={modalRef}
+        tabIndex={-1}
         className={clsx(
-          'bg-normal',
-          // 모바일 사이즈
+          'bg-normal outline-none',
           isFullOnMobile
             ? 'w-full h-full rounded-none max-h-none'
             : 'w-auto h-auto rounded-2xl max-h-[calc(100vh-40px)]',
-          // 데스크탑(md 이상)
           'md:w-auto md:h-auto md:rounded-2xl md:max-h-[calc(100vh-40px)]',
           className
         )}
         style={{
-          // md 이상에서만 적용되는 인라인 크기
-          width: width ? `${width}px` : undefined,
-          height: height ? `${height}px` : undefined
+          width: typeof width === 'number' ? `${width}px` : width,
+          height: typeof height === 'number' ? `${height}px` : height
         }}
-        onClick={(e) => e.stopPropagation()}
       >
-        {/* 공통 헤더 */}
-        <div
-          className={clsx(
-            'flex justify-between items-center',
-            'py-3 pb-2 px-4',
-            'border-b-2 border-gray-90'
-          )}
-        >
-          {/* 모바일: 뒤로가기, 데스크탑: 자리 확보 */}
-          <button
-            onClick={close}
-            type="button"
-            className={clsx(
-              'w-7 h-7 flex items-center justify-center',
-              'md:hidden'
-            )}
-          >
-            <BackButton />
-          </button>
-          <div className="hidden md:block w-7 h-7" />
-
-          <h3 className={clsx('flex-1', 'text-center', 'text-lg font-medium')}>
-            {headerTitle}
-          </h3>
-
-          {/* 모바일: 빈 공간, 데스크탑: 닫기 버튼 */}
-          <div className="hidden md:block w-7 h-7" />
-          <button
-            type="button"
-            onClick={close}
-            className={clsx(
-              'w-7 h-7 flex items-center justify-center text-xl font-bold',
-              'hidden md:flex'
-            )}
-          >
-            <XClose />
-          </button>
-        </div>
-
-        {/* 모달 콘텐츠 */}
-        <div className={clsx('overflow-auto', 'p-4')}>{children}</div>
+        <ModalHeader
+          titleId={titleId}
+          title={headerTitle}
+          custom={header}
+          onClose={close}
+        />
+        <div className="overflow-auto p-4">{children}</div>
       </div>
+    </div>
+  );
+
+  // createPortal Docs:
+  // https://react.dev/reference/react-dom/createPortal
+  return createPortal(content, document.body);
+};
+
+const ModalHeader: React.FC<{
+  titleId: string;
+  title?: string;
+  custom?: React.ReactNode;
+  onClose: () => void;
+}> = ({ titleId, title, custom, onClose }) => {
+  if (custom) {
+    return (
+      <div
+        className={clsx(
+          'flex justify-between items-center',
+          'py-3 pb-2 px-4',
+          'border-b-2 border-gray-90'
+        )}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          className="w-7 h-7 flex items-center justify-center md:hidden"
+          aria-label="닫기"
+        >
+          <BackButton />
+        </button>
+        <div className="hidden md:block w-7 h-7" aria-hidden />
+        <div className="flex-1">{custom}</div>
+        <div className="hidden md:block w-7 h-7" aria-hidden />
+        <button
+          type="button"
+          onClick={onClose}
+          className="w-7 h-7 hidden md:flex items-center justify-center"
+          aria-label="닫기"
+        >
+          <XClose />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={clsx(
+        'flex justify-between items-center',
+        'py-3 pb-2 px-4',
+        'border-b-2 border-gray-90'
+      )}
+    >
+      <button
+        type="button"
+        onClick={onClose}
+        className="w-7 h-7 flex items-center justify-center md:hidden"
+        aria-label="닫기"
+      >
+        <BackButton />
+      </button>
+      <div className="hidden md:block w-7 h-7" aria-hidden />
+      <h3 id={titleId} className="flex-1 text-center text-lg font-medium">
+        {title}
+      </h3>
+      <div className="hidden md:block w-7 h-7" aria-hidden />
+      <button
+        type="button"
+        onClick={onClose}
+        className="w-7 h-7 hidden md:flex items-center justify-center"
+        aria-label="닫기"
+      >
+        <XClose />
+      </button>
     </div>
   );
 };

--- a/src/components/ui/RadioGroup.tsx
+++ b/src/components/ui/RadioGroup.tsx
@@ -1,3 +1,4 @@
+// RadioGroup.tsx
 import clsx from 'clsx';
 import React from 'react';
 
@@ -17,18 +18,8 @@ interface RadioGroupProps {
 
 /**
  * 커스텀 라디오 그룹 컴포넌트
- *
- * @param {string} name - `<input>` 요소 name 속성 (그룹 구분자)
- * @param {RadioOption[]} options - {
-  value: any;
-  label: string | React.ReactNode;
-}[]
- * @param {any} selectedValue - 현재 선택된 값. state
- * @param {(value: any) => void} onChange - 라디오 버튼 선택이 변경되었을 때 호출되는 콜백
- * @param {boolean} [withDivider=false] - 각 옵션 사이에 구분선을 표시할지 여부
- * @param {string} - 라벨 사이즈 텍스트 !! px !!
  */
-export const RadioGroup: React.FC<RadioGroupProps> = ({
+const RadioGroup: React.FC<RadioGroupProps> = ({
   name,
   options,
   selectedValue,
@@ -40,7 +31,9 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
     <div className="flex flex-col gap-2">
       {options.map((option, index) => (
         <div key={option.value}>
-          <label className={clsx('flex items-center gap-2 cursor-pointer')}>
+          <label
+            className={clsx('flex items-center gap-2', 'cursor-pointer w-full')}
+          >
             <input
               type="radio"
               name={name}
@@ -51,7 +44,7 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
             />
             <div
               className={clsx(
-                'w-[20px] h-[20px] rounded-full flex items-center justify-center',
+                'mt-1 w-[20px] h-[20px] rounded-full flex items-center justify-center flex-none',
                 selectedValue === option.value
                   ? 'bg-primary-20 border-[1px] border-primary-20'
                   : 'border-gray-70 border-[1px]'
@@ -61,17 +54,24 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
                 <div className="w-[10px] h-[10px] bg-white rounded-full" />
               )}
             </div>
-            <span
-              className={clsx(
-                selectedValue === option.value
-                  ? 'text-primary-20'
-                  : 'text-label-normal'
-              )}
-              style={{ fontSize: labelTextSize }}
-            >
-              {option.label}
-            </span>
+
+            {/* label: 문자열은 인라인, ReactNode는 블록 카드 */}
+            {typeof option.label === 'string' ? (
+              <span
+                className={clsx(
+                  selectedValue === option.value
+                    ? 'text-primary-20'
+                    : 'text-label-normal'
+                )}
+                style={{ fontSize: labelTextSize }}
+              >
+                {option.label}
+              </span>
+            ) : (
+              <div className="flex-1">{option.label}</div>
+            )}
           </label>
+
           {withDivider && index < options.length - 1 && (
             <hr className="border-gray-90 h-[1px] mt-2" />
           )}

--- a/src/zustand/payment/useDeliveryStore.ts
+++ b/src/zustand/payment/useDeliveryStore.ts
@@ -5,14 +5,13 @@ import { createJSONStorage, persist } from 'zustand/middleware';
 type State = {
   selectedAddressId: string | null;
   shippingRequest: string | null;
-  address: Address | null;
+  address: Address[] | null;
   shouldStoreDeliveryRequest: boolean;
 }
 type Actions = {
-  //TODO setSelectedAddressId 필요할지 고려
   setSelectedAddressId: (id: string) => void;
   setShippingRequest: (req: string) => void;
-  setAddress: (state: Address) => void;
+  setAddress: (state: Address[]) => void;
   setShouldStoreDeliveryRequest: (shouldStore: boolean) => void;
 }
 
@@ -26,9 +25,9 @@ const useDeliveryStore = create<State&Actions>()(
   
   setSelectedAddressId:(id)=>set({selectedAddressId: id}),
   setShippingRequest: (req) => set({shippingRequest: req}),
-  setAddress: (address) =>
+  setAddress: (addresses) =>
     set((state) =>
-      state.address !== address ? { address } : state
+      state.address !== addresses ? { address: addresses } : state
 ),
 setShouldStoreDeliveryRequest: (shouldStore) => set({shouldStoreDeliveryRequest: shouldStore}),
   

--- a/src/zustand/payment/useDeliveryStore.ts
+++ b/src/zustand/payment/useDeliveryStore.ts
@@ -15,9 +15,6 @@ type Actions = {
   setShouldStoreDeliveryRequest: (shouldStore: boolean) => void;
 }
 
-//TODO "다음에도 사용할래요" 체크가 true면, 
-//shippingRequest를 로컬 스토리지에 저장해두고 다음 진입 시 복원하는 
-// 구조도 고려
 const useDeliveryStore = create<State&Actions>()(
   persist(
   (set)=>({

--- a/src/zustand/payment/useDeliveryStore.ts
+++ b/src/zustand/payment/useDeliveryStore.ts
@@ -15,6 +15,9 @@ type Actions = {
   setShouldStoreDeliveryRequest: (shouldStore: boolean) => void;
 }
 
+//TODO "다음에도 사용할래요" 체크가 true면, 
+//shippingRequest를 로컬 스토리지에 저장해두고 다음 진입 시 복원하는 
+// 구조도 고려
 const useDeliveryStore = create<State&Actions>()(
   persist(
   (set)=>({


### PR DESCRIPTION
# 결제 페이지 배송지 변경/추가 UX 개선 및 모달 접근성 강화

## 주요 변경 사항

### 1. 결제 페이지 헤더 및 컴포넌트 구조 변경
- 결제 페이지에서 헤더가 노출되도록 수정
- `DesktopOrderHeader` → `OrderPageIntro`로 컴포넌트명 변경

### 2. 배송지 렌더 로직 개선
- 초기 렌더 시 서버 props를 바로 사용 (불필요한 `useState` 제거)
- 이후 배송지 변경 시 `zustand` state 사용
- 선택된 배송지 > 기본 배송지 > 없으면 `null` 순으로 우선 렌더

### 3. 배송지 변경/추가 UX 리팩터링
- 배송지 변경 모달 리스트를 `RadioGroup` 기반 커스텀 UI로 교체
- 모달 내에서 ‘새 배송지 추가’ 버튼 및 폼 전환/뒤로가기 동작 지원
- `AddAddressForm`에 `onSuccess`, `onCancel` 콜백 props 추가
- 모달 닫힘 또는 등록 완료 시 mode state 초기화 로직 추가
- 결제페이지/마이페이지 상황에 따른 완료 후 동작(router 이동 or 모달 닫기) 분기

### 4. Modal 컴포넌트 접근성 및 동작 개선
- `role`, `aria-modal`, `aria-labelledby` 속성 추가
- 스크롤 락 및 열릴 때 컨테이너 포커스 적용
- `Esc` 키로 모달 닫기 지원
- `createPortal` 기반 구조로 변경

### 5. 디자인 및 반응형 개선
- 간격, width 등 스타일 수정
- 모바일 ↔ 데스크탑 전환 시 버벅임 없이 적절한 모드(전체화면/모달) 적용

### 6. 기타
- 미사용 상태 제거
- 언마운트 시 storage reset
