### PR TITLE
결제 페이지 - 배송지 상태 안정화 및 수정

### DIFF
--- a/src/app/(pages)/(payment)/payment/components/(address)/AddAddressButton.tsx
+++ b/src/app/(pages)/(payment)/payment/components/(address)/AddAddressButton.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import AddAddressForm from '@/components/common/address/AddAddressForm';
 import PlusIcon from '@/components/icons/PlusIcon';
 import { Modal } from '@/components/ui/Modal';
 import { MODAL_IDS } from '@/constants';
@@ -6,6 +9,13 @@ import clsx from 'clsx';
 
 const AddAddressButton = () => {
   const open = useModalStore((state) => state.open);
+  const closeModal = useModalStore((s) => s.close);
+
+  const onSuccess = () => {
+    closeModal();
+    window.location.reload();
+  };
+
   return (
     <>
       <button
@@ -28,7 +38,7 @@ const AddAddressButton = () => {
         isFullOnMobile
         modalId={MODAL_IDS.ADDRESS}
       >
-        <div>dd</div>
+        <AddAddressForm onSuccess={onSuccess} />
       </Modal>
     </>
   );

--- a/src/app/(pages)/(payment)/payment/components/(address)/AddAddressButton.tsx
+++ b/src/app/(pages)/(payment)/payment/components/(address)/AddAddressButton.tsx
@@ -11,11 +11,6 @@ const AddAddressButton = () => {
   const open = useModalStore((state) => state.open);
   const closeModal = useModalStore((s) => s.close);
 
-  const onSuccess = () => {
-    closeModal();
-    window.location.reload();
-  };
-
   return (
     <>
       <button
@@ -38,7 +33,7 @@ const AddAddressButton = () => {
         isFullOnMobile
         modalId={MODAL_IDS.ADDRESS}
       >
-        <AddAddressForm onSuccess={onSuccess} />
+        <AddAddressForm onSuccess={closeModal} />
       </Modal>
     </>
   );

--- a/src/app/(pages)/(payment)/payment/components/(address)/AddressSummaryCard.tsx
+++ b/src/app/(pages)/(payment)/payment/components/(address)/AddressSummaryCard.tsx
@@ -1,16 +1,45 @@
 import { Address } from '@/types/deliveryAddress';
-import React from 'react';
+import useDeliveryStore from '@/zustand/payment/useDeliveryStore';
+import React, { useEffect } from 'react';
 
 interface Props {
-  selectedAddress: Address;
+  selectedAddress: Address | null;
 }
 
-const AddressSummaryCard: React.FC<Props> = ({ selectedAddress }) => {
-  const { addressName, receiverName, phoneNumber, baseAddress, detailAddress } =
-    selectedAddress;
+const AddressSummaryCard: React.FC<Props> = ({}) => {
+  // 파생값을 한 번에 계산
+  const snap = useDeliveryStore((s) => {
+    const list = s.address ?? [];
+    const selectedId = s.selectedAddressId ?? null; // undefined도 null 취급
+    const fallbackId = list[0]?.id ?? null;
+    const effectiveId = selectedId ?? fallbackId; // 보정된 ID
+    const selected = effectiveId
+      ? list.find((a) => a.id === effectiveId) ?? null
+      : null;
 
-  const zipCode = baseAddress.match(/\((\d+)\)/)?.[1];
-  const baseAddressWithoutZipCode = baseAddress.split('(')[0];
+    return { list, selected, effectiveId, rawSelectedId: s.selectedAddressId };
+  });
+
+  useEffect(() => {
+    if (!snap.rawSelectedId && snap.effectiveId) {
+      // selectedAddressId가 null/undefined라면 보정 ID로 설정
+      useDeliveryStore.getState().setSelectedAddressId(snap.effectiveId);
+    }
+  }, [snap.rawSelectedId, snap.effectiveId]);
+
+  if (!snap.selected) return null;
+
+  const {
+    addressName = '',
+    receiverName = '',
+    phoneNumber = '',
+    baseAddress = '',
+    detailAddress = ''
+  } = snap.selected;
+  const zipCode = baseAddress.match(/\((\d+)\)/)?.[1] ?? '';
+  const baseAddressWithoutZipCode = baseAddress
+    ? baseAddress.split('(')[0]
+    : '';
 
   return (
     <div className="flex flex-col gap-2">
@@ -26,7 +55,7 @@ const AddressSummaryCard: React.FC<Props> = ({ selectedAddress }) => {
           {baseAddressWithoutZipCode}
           {detailAddress && detailAddress.trim() && <p>, {detailAddress}</p>}
         </div>
-        <p>({zipCode})</p>
+        {zipCode && <p>({zipCode})</p>}
       </div>
     </div>
   );

--- a/src/app/(pages)/(payment)/payment/components/OrderSummary.tsx
+++ b/src/app/(pages)/(payment)/payment/components/OrderSummary.tsx
@@ -11,7 +11,7 @@ import { useCouponDiscount } from '@/hooks/coupon/useCouponDiscount';
 import { useUser } from '@/hooks/useUser';
 
 import Accordion from '@/components/ui/Accordion';
-import { ACCORDION_IDS, DELIVERY_FEE } from '@/constants';
+import { ACCORDION_IDS, DELIVERY_FEE, ROUTES } from '@/constants';
 import { startBackGuard } from '@/utils/popstateGuard';
 import useDeliveryStore from '@/zustand/payment/useDeliveryStore';
 import { usePaymentRequestStore } from '@/zustand/payment/usePaymentStore';
@@ -60,7 +60,7 @@ const OrderSummary = () => {
     }
     if (!user) {
       console.error('Get user failed');
-      router.push('/login');
+      router.push(ROUTES.LOG_IN);
       return toast({
         description: '로그인이 필요합니다. 로그인 후 다시 시도해주세요'
       });

--- a/src/app/(pages)/(payment)/payment/components/OrderSummary.tsx
+++ b/src/app/(pages)/(payment)/payment/components/OrderSummary.tsx
@@ -65,7 +65,8 @@ const OrderSummary = () => {
         description: '로그인이 필요합니다. 로그인 후 다시 시도해주세요'
       });
     }
-    if (!address) {
+    console.log(address);
+    if (address?.length === 0) {
       return toast({ description: '배송지 추가 혹은 선택 해주세요' });
     }
 

--- a/src/components/common/address/AddAddressForm.tsx
+++ b/src/components/common/address/AddAddressForm.tsx
@@ -179,7 +179,7 @@ const AddAddressForm: React.FC<AddAddressFormProps> = ({ onSuccess }) => {
       phoneNumber: false,
       baseAddress: false
     });
-    e.currentTarget.reset();
+    formEl.reset();
 
     onSuccess?.();
   };

--- a/src/components/ui/PayButton.tsx
+++ b/src/components/ui/PayButton.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ROUTES } from '@/constants';
 import { useUser } from '@/hooks/useUser';
 import { usePaymentRequestStore } from '@/zustand/payment/usePaymentStore';
 import clsx from 'clsx';
@@ -59,7 +60,7 @@ export default function PayButton({ orderNameArr, product, variant }: Props) {
   const handleClick = () => {
     if (!nowUser) {
       toast({ description: '로그인 후 이용 가능합니다' });
-      router.push('/login');
+      router.push(ROUTES.LOG_IN);
       return;
     }
     if (product.length === 0) {
@@ -71,7 +72,7 @@ export default function PayButton({ orderNameArr, product, variant }: Props) {
     setOrderName(formatOrderName(orderNameArr));
     setProducts(product as any);
 
-    router.push('/payment');
+    router.push(ROUTES.PAYMENT);
   };
 
   const className = clsx(

--- a/src/components/ui/RadioGroup.tsx
+++ b/src/components/ui/RadioGroup.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 interface RadioOption {
   value: any;
@@ -26,6 +26,19 @@ const RadioGroup: React.FC<RadioGroupProps> = ({
   withDivider = false,
   labelTextSize
 }) => {
+  // 현재 selectedValue가 유효한지 검사
+  const hasSelectedInOptions = useMemo(
+    () => options.some((opt) => opt.value === selectedValue),
+    [options, selectedValue]
+  );
+
+  // 마운트/옵션 변경 시, 선택값이 없거나 잘못된 경우 첫 번째로 강제 세팅
+  useEffect(() => {
+    if (options.length === 0) return;
+    if (!hasSelectedInOptions) {
+      onChange(options[0].value);
+    }
+  }, [options, hasSelectedInOptions, onChange]);
   return (
     <div className="flex flex-col gap-2">
       {options.map((option, index) => (

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,3 @@
-// 사이트 URL 상수
 export const SITE_URL = process.env.NEXT_PUBLIC_BASE_URL!;
 
 export const ROUTES  = {
@@ -9,6 +8,7 @@ export const ROUTES  = {
   INTERESTED_MARKET_PATH: '/my-page/likemarket-page' as const,
   LOCAL_FOOD: '/local-food' as const,
   CART: '/cart' as const,
+  PAYMENT: '/payment' as const,
   PAYMENT_HISTORY: '/pay-history' as const,
   MY_PAGE: '/my-page' as const,
   COUPON: '/my-page/coupon-page' as const,
@@ -17,6 +17,10 @@ export const ROUTES  = {
   NOTICE: '/customer-service/announcement' as const,
   FAQ: '/customer-service/faq-page' as const,
 }
+
+export const TEST_USER_IDS = new Set([
+  '5359e616-84a1-44c7-bcd5-831d78a30292',
+])
 
 // 전역 모달 ID. Modal.tsx
 export const MODAL_IDS = {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -18,10 +18,6 @@ export const ROUTES  = {
   FAQ: '/customer-service/faq-page' as const,
 }
 
-export const TEST_USER_IDS = new Set([
-  '5359e616-84a1-44c7-bcd5-831d78a30292',
-])
-
 // 전역 모달 ID. Modal.tsx
 export const MODAL_IDS = {
   COUPON: 'coupon',

--- a/src/zustand/payment/useDeliveryStore.ts
+++ b/src/zustand/payment/useDeliveryStore.ts
@@ -6,32 +6,79 @@ type State = {
   shippingRequest: string | null;
   address: Address[] | null;
   shouldStoreDeliveryRequest: boolean;
-}
+};
+
 type Actions = {
-  setSelectedAddressId: (id: string) => void;
-  setShippingRequest: (req: string) => void;
-  setAddress: (state: Address[]) => void;
+  setSelectedAddressId: (id: string | null) => void;
+  setShippingRequest: (req: string | null) => void;
+  setAddress: (addresses: Address[]) => void;
+  addAddress: (address: Address | { status: number; address: Address }) => void; // ← 래핑 허용
+  removeAddress: (id: string) => void;
   setShouldStoreDeliveryRequest: (shouldStore: boolean) => void;
   resetAddressStore: () => void;
-}
+};
 
-const eqById = (a: Address[] | null, b: Address[]) =>
-  !!a && a.length === b.length && a.every((x, i) => x.id === b[i].id);
-
-const useDeliveryStore = create<State&Actions>()(
-  (set)=>({
+export const useDeliveryStore = create<State & Actions>((set, get) => ({
   selectedAddressId: null,
   shippingRequest: null,
   address: null,
   shouldStoreDeliveryRequest: false,
-  
-  setSelectedAddressId:(id)=>set({selectedAddressId: id}),
-  setShippingRequest: (req) => set({shippingRequest: req}),
+
+  setSelectedAddressId: (id) => set({ selectedAddressId: id }),
+  setShippingRequest: (req) => set({ shippingRequest: req }),
+
   setAddress: (addresses) =>
-    set((s) => (eqById(s.address, addresses) ? s : { address: addresses })),
-  
-  setShouldStoreDeliveryRequest: (shouldStore) => set({shouldStoreDeliveryRequest: shouldStore}),
-  resetAddressStore: () => set({ selectedAddressId: null, address: null }),
-}),)
+    set((s) => {
+      const next = addresses.map((a: any) =>
+        'address' in a ? ({ ...(a.address as Address) }) : ({ ...(a as Address) })
+      );
+      const hasSelected =
+        s.selectedAddressId != null && next.some((a) => a.id === s.selectedAddressId);
+
+      return {
+        address: next,
+        selectedAddressId: hasSelected ? s.selectedAddressId : next[0]?.id ?? null,
+      };
+    }),
+
+  addAddress: (payload) => {
+    const item =
+      payload && typeof payload === 'object' && 'address' in (payload as any)
+        ? (payload as any).address as Address
+        : (payload as Address);
+
+    set((s) => {
+      const base = (s.address ?? []).map((a) => ({ ...a }));
+      const idx = base.findIndex((a) => a.id === item.id);
+      const next = idx >= 0
+        ? base.map((a) => (a.id === item.id ? { ...item } : a))
+        : [...base, { ...item }];
+
+      const nextSelectedId = s.selectedAddressId ?? item.id ?? next[0]?.id ?? null;
+
+      return { address: next, selectedAddressId: nextSelectedId };
+    });
+  },
+
+  removeAddress: (id) =>
+    set((s) => {
+      const base = (s.address ?? []).map((a) => ({ ...a }));
+      const next = base.filter((a) => a.id !== id);
+      const nextSelected =
+        s.selectedAddressId === id ? next[0]?.id ?? null : s.selectedAddressId;
+      return { address: next, selectedAddressId: nextSelected };
+    }),
+
+  setShouldStoreDeliveryRequest: (shouldStore) =>
+    set({ shouldStoreDeliveryRequest: shouldStore }),
+
+  resetAddressStore: () =>
+    set({
+      selectedAddressId: null,
+      shippingRequest: null,
+      address: null,
+      shouldStoreDeliveryRequest: false,
+  }),
+}));
 
 export default useDeliveryStore;


### PR DESCRIPTION
### 목적

- 배송지 추가 / 삭제 / 수정 시 ui 변경 지연 해결


### 변경 요약

1. zustand 배송지 스토어 리팩토링
- addAddress : { status, address } 형태 래핑/언랩 지원
- removeAddress : 삭제 대상이 선택되어 있을 시 선택 ID 재보정
- 모든 내부 갱신에 얕은 복사 적용 (불변성 유지)

2. (1) 변경 사항에 맞춘 `DeliveryAddress` `AddressSummaryCard` `AddressesList` `AddAddressForm` 리팩토링

3. 상수 적용 안 된 부분 리팩토링
4. RadioGroup - 선택된 옵션 없을 시 첫번째 요소 선택되게 수정 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 배송지 추가 폼을 모달에서 지원하고, 등록 성공 시 자동 닫힘 및 해당 주소 자동 선택.
  - 주소 목록 편집/삭제에 낙관적 업데이트 적용 및 상태 동기화.
  - 옵션형 라디오 그룹에서 유효한 기본 선택 자동 보장.
  - 공용 경로 상수에 결제 페이지 추가, 관련 버튼/흐름에서 사용.

- Bug Fixes
  - 주문 요약의 주소 검증 로직 보완(빈 문자열 처리).
  - 주소 요약에서 우편번호 표기 조건 개선 및 빈 상태 가드.

- Refactor
  - 결제 주소 관련 상태를 공용 스토어로 일원화하고 선택 로직 자동화.
  - 컴포넌트 구조 및 내보내기 패턴 정리, 클래스명/토글 처리 단순화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->